### PR TITLE
Fix bug in search box (spaces can't be typed)

### DIFF
--- a/docs/scripts.js
+++ b/docs/scripts.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const isHdmiFilterEnabled = getQueryParm(queryParams.hdmi) === 'true';
         const isGridFilterEnabled = getQueryParm(queryParams.grid) === 'true';
         const isLanguageFilterEnabled = getQueryParm(queryParams.language) === 'true';
-        const searchFilter = getQueryParm(queryParams.search)?.trim() ?? '';
+        const searchFilter = getQueryParm(queryParams.search) ?? '';
 
         // Update filter UI
         deviceFilterMenu.value = deviceFilter;


### PR DESCRIPTION
Oops. The trimmed value is sync'd back into the text field, meaning spaces disappear immediately when typed. Fixed by removing the `trim()`, as it's not really necessary anyway.